### PR TITLE
Update dockerfile and simulation manager to NEST 3.0

### DIFF
--- a/nest-module/Dockerfile
+++ b/nest-module/Dockerfile
@@ -18,7 +18,7 @@ RUN cmake \
     /cpprestsdk
 RUN ninja && ninja install
 
-RUN git clone --single-branch --branch simulation-time https://github.com/babsey/nest-simulator.git /nest
+RUN git clone --single-branch --branch v3.0 https://github.com/nest/nest-simulator.git /nest
 WORKDIR /nest-build
 RUN cmake \
     -G Ninja \

--- a/nest-module/src/recording_backend_insite.cpp
+++ b/nest-module/src/recording_backend_insite.cpp
@@ -74,8 +74,8 @@ void RecordingBackendInsite::cleanup() {
 
 void RecordingBackendInsite::pre_run_hook() {
   data_storage_.SetSimulationTimeRange(
-      nest::kernel().simulation_manager.get_simulate_from().get_ms(),
-      nest::kernel().simulation_manager.get_simulate_to().get_ms());
+      nest::kernel().simulation_manager.run_start_time().get_ms(),
+      nest::kernel().simulation_manager.run_end_time().get_ms());
 }
 
 void RecordingBackendInsite::post_run_hook() {


### PR DESCRIPTION
This PR updates 

- [x] Dockerfile that it pulls offical image of NEST Simulator 
- [x] Rename the function of Simulation Manager in NEST (See https://github.com/nest/nest-simulator/pull/2030)