### PR TITLE
Download release file of NEST

### DIFF
--- a/nest-module/Dockerfile
+++ b/nest-module/Dockerfile
@@ -62,12 +62,17 @@ RUN python3 -m pip install \
     RestrictedPython
 
 ARG NEST_SRC_PATH=/tmp/nest-simulator
-ARG NEST_VERSION=3.3
 
-RUN wget https://github.com/nest/nest-simulator/archive/refs/tags/v${NEST_VERSION}.tar.gz && \
-    tar -zxf v${NEST_VERSION}.tar.gz && \
-    rm -rf v${NEST_VERSION}.tar.gz && \
-    mv nest-simulator-${NEST_VERSION} ${NEST_SRC_PATH}
+# Clone working copy from GitHub
+ARG NEST_GIT_BRANCH=master
+RUN git clone --depth 1 --branch ${NEST_GIT_BRANCH} https://github.com/nest/nest-simulator.git ${NEST_SRC_PATH}
+
+# Download release files
+# ARG NEST_VERSION=3.3
+# RUN wget https://github.com/nest/nest-simulator/archive/refs/tags/v${NEST_VERSION}.tar.gz && \
+#     tar -zxf v${NEST_VERSION}.tar.gz && \
+#     rm -rf v${NEST_VERSION}.tar.gz && \
+#     mv nest-simulator-${NEST_VERSION} ${NEST_SRC_PATH}
 
 # Install requirements for NEST documentation
 RUN python3 -m pip install -r ${NEST_SRC_PATH}/doc/requirements.txt
@@ -82,7 +87,7 @@ RUN cmake \
     -DCMAKE_BUILD_TYPE=Release \
     ${NEST_SRC_PATH}
 RUN ninja \
-    && ninja html \
+    # && ninja html \
     && ninja install
 
 

--- a/nest-module/Dockerfile
+++ b/nest-module/Dockerfile
@@ -54,9 +54,6 @@ RUN cmake \
 RUN ninja && ninja install
 
 
-# Install NEST Simulator
-ARG NEST_SRC_PATH=/tmp/nest-simulator
-
 # Install dependencies for NEST Server
 RUN python3 -m pip install \
     gunicorn \
@@ -64,10 +61,13 @@ RUN python3 -m pip install \
     Flask-cors \
     RestrictedPython
 
-# Clone NEST Simulator
-ARG NEST_GIT_BRANCH=v3.3
-RUN git clone --depth 1 --branch ${NEST_GIT_BRANCH} https://github.com/nest/nest-simulator.git ${NEST_SRC_PATH}
-WORKDIR ${NEST_SRC_PATH}
+ARG NEST_SRC_PATH=/tmp/nest-simulator
+ARG NEST_VERSION=3.3
+
+RUN wget https://github.com/nest/nest-simulator/archive/refs/tags/v${NEST_VERSION}.tar.gz && \
+    tar -zxf v${NEST_VERSION}.tar.gz && \
+    rm -rf v${NEST_VERSION}.tar.gz && \
+    mv nest-simulator-${NEST_VERSION} ${NEST_SRC_PATH}
 
 # Install requirements for NEST documentation
 RUN python3 -m pip install -r ${NEST_SRC_PATH}/doc/requirements.txt


### PR DESCRIPTION
The NEST module doesn't return the correct version (v3.3) because the source code was cloned from github.

To fix this issue, we need to download the release file of NEST Simulator.