### PR TITLE
Make env variables for NEST Server as default

### DIFF
--- a/docker-compose-testing.yml
+++ b/docker-compose-testing.yml
@@ -16,8 +16,3 @@ services:
       - "9000-9005:9000-9005"
     environment:
       INSITE_DOCKER_USE_NEST_SERVER: 0
-      NEST_SERVER_HOST: "0.0.0.0"
-      NEST_SERVER_MODULES: "nest,numpy"
-      NEST_SERVER_PORT: 5000
-      NEST_SERVER_RESTRICTION_OFF: 1
-      NEST_SERVER_STDOUT: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   insite-nest-module:
     build: ./nest-module
     ports:
-      - "5000:5000"
+      - "52425:52425"
       - "9000-9005:9000-9005"
     environment:
       INSITE_DOCKER_USE_NEST_SERVER: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,3 @@ services:
       - "9000-9005:9000-9005"
     environment:
       INSITE_DOCKER_USE_NEST_SERVER: 1
-      NEST_SERVER_HOST: "0.0.0.0"
-      NEST_SERVER_MODULES: "nest,numpy"
-      NEST_SERVER_PORT: 5000
-      NEST_SERVER_RESTRICTION_OFF: 1
-      NEST_SERVER_STDOUT: 1

--- a/nest-module/Dockerfile
+++ b/nest-module/Dockerfile
@@ -64,8 +64,13 @@ RUN python3 -m pip install \
     Flask-cors \
     RestrictedPython
 
+# Install dependencies for NEST Server MPI
+RUN python3 -m pip install \
+    docopt \
+    mpi4py
+
 # Clone NEST Simulator
-ARG NEST_GIT_BRANCH=v3.3
+ARG NEST_GIT_BRANCH=master
 RUN git clone --depth 1 --branch ${NEST_GIT_BRANCH} https://github.com/nest/nest-simulator.git ${NEST_SRC_PATH}
 WORKDIR ${NEST_SRC_PATH}
 
@@ -82,7 +87,7 @@ RUN cmake \
     -DCMAKE_BUILD_TYPE=Release \
     ${NEST_SRC_PATH}
 RUN ninja \
-    && ninja html \
+    # && ninja html \
     && ninja install
 
 

--- a/nest-module/src/scripts/start_script.sh.in
+++ b/nest-module/src/scripts/start_script.sh.in
@@ -4,16 +4,21 @@
 source @NEST_INSTALL_PREFIX@/bin/nest_vars.sh
 export LD_LIBRARY_PATH=$NEST_MODULE_PATH:/usr/local/lib/:$LD_LIBRARY_PATH
 
-if [ "$INSITE_DOCKER_USE_NEST_SERVER" == 1 ]
+export NEST_SERVER_HOST="${NEST_SERVER_HOST:-0.0.0.0}"
+export NEST_SERVER_MODULES="${NEST_SERVER_MODULES:-nest,numpy}"
+export NEST_SERVER_PORT="${NEST_SERVER_PORT:-52425}"
+export NEST_SERVER_RESTRICTION_OFF="${NEST_SERVER_RESTRICTION_OFF:-1}"
+export NEST_SERVER_STDOUT="${NEST_SERVER_STDOUT:-1}"
+
+if [ "$INSITE_DOCKER_USE_NEST_SERVER_MPI" == 1 ]
 then
-    echo "Running with NEST SERVER"
-    export NEST_SERVER_HOST="${NEST_SERVER_HOST:-0.0.0.0}"
-    export NEST_SERVER_MODULES="${NEST_SERVER_MODULES:-nest,numpy}"
-    export NEST_SERVER_PORT="${NEST_SERVER_PORT:-5000}"
-    export NEST_SERVER_RESTRICTION_OFF="${NEST_SERVER_RESTRICTION_OFF:-1}"
-    export NEST_SERVER_STDOUT="${NEST_SERVER_STDOUT:-1}"
+    echo "Running with NEST Server MPI"
+    mpirun -np 1 --allow-run-as-root nest-server-mpi --host $NEST_SERVER_HOST
+elif [ "$INSITE_DOCKER_USE_NEST_SERVER" == 1 ]
+then
+    echo "Running with NEST Server"
     nest-server start
 else
-    echo "Running without NEST SERVER"
+    echo "Running simulation of the scripted code"
     source run_simulation.sh
 fi

--- a/nest-module/src/scripts/start_script.sh.in
+++ b/nest-module/src/scripts/start_script.sh.in
@@ -7,6 +7,11 @@ export LD_LIBRARY_PATH=$NEST_MODULE_PATH:/usr/local/lib/:$LD_LIBRARY_PATH
 if [ "$INSITE_DOCKER_USE_NEST_SERVER" == 1 ]
 then
     echo "Running with NEST SERVER"
+    export NEST_SERVER_HOST="${NEST_SERVER_HOST:-0.0.0.0}"
+    export NEST_SERVER_MODULES="${NEST_SERVER_MODULES:-nest,numpy}"
+    export NEST_SERVER_PORT="${NEST_SERVER_PORT:-5000}"
+    export NEST_SERVER_RESTRICTION_OFF="${NEST_SERVER_RESTRICTION_OFF:-1}"
+    export NEST_SERVER_STDOUT="${NEST_SERVER_STDOUT:-1}"
     nest-server start
 else
     echo "Running without NEST SERVER"


### PR DESCRIPTION
All environment variables for NEST server instance can be used as defaults in `script.sh` file.
The user still can modify some env variables in config file of docker-compose.